### PR TITLE
Add overloaded startDriver to provide default capabilities

### DIFF
--- a/src/main/scala/com/gu/automation/core/WebDriverBase.scala
+++ b/src/main/scala/com/gu/automation/core/WebDriverBase.scala
@@ -8,4 +8,5 @@ import org.openqa.selenium.WebDriver
 trait WebDriverBase[T <: WebDriver] {
 
   protected def startDriver(testName: String, extraCapabilities: Map[String, String] = Map()): T
+  protected def startDriver(testName: String): T = startDriver(testName, Map())
 }


### PR DESCRIPTION
In order to avoid confusion I have added an overloaded startDriver that will provide an empty extra capabilities map.
