### PR TITLE
Added browserstack local property in capabilities

### DIFF
--- a/src/main/resources/framework.conf
+++ b/src/main/resources/framework.conf
@@ -10,5 +10,6 @@
 "resolution" 	      		: "1280x1024" //only if you are using a remote driver for Browserstack
 "platformVersion"      	: "7" //only if you are using a remote driver for Browserstack
 "browserStackVisualLog" : "true" //only if you are using a remote driver for Browserstack. Enables logs with screenshots
+"browserStackLocal"     : false //Set this to true if you are using BrowserStackLocal
 
 "autoAcceptSSLCert"     : false //This tells the browser capability to automatically accept not validated SSL certs

--- a/src/main/scala/com/gu/automation/core/webdriver/BrowserStackWebDriverFactory.scala
+++ b/src/main/scala/com/gu/automation/core/webdriver/BrowserStackWebDriverFactory.scala
@@ -30,6 +30,7 @@ object BrowserStackWebDriverFactory extends ParentWebDriverFactory {
     targetBrowser.version.foreach(capabilities.setCapability("browser_version", _))
     resolution.foreach(capabilities.setCapability("resolution", _))
     browserStackVisualLog.foreach(capabilities.setCapability("browserstack.debug", _))
+    capabilities.setCapability("browserstack.local", s"${Config().isBrowserStackLocal()}")
     capabilities
   }
 }

--- a/src/main/scala/com/gu/automation/support/Config.scala
+++ b/src/main/scala/com/gu/automation/support/Config.scala
@@ -98,6 +98,10 @@ class Config(localFile: Option[Reader], projectFile: Option[Reader], frameworkFi
     config.getBoolean("autoAcceptSSLCert")
   }
 
+  def isBrowserStackLocal(): Boolean = {
+    config.getBoolean("browserStackLocal")
+  }
+
   def getIdApiRoot(): String = {
     getConfigValue("idApiRoot")
   }


### PR DESCRIPTION
As subject says. It is needed if you are going to use the BrowserStack proxy called BrowserStackLocal. See http://www.browserstack.com/local-testing
