### PR TITLE
Parallel mobile

### DIFF
--- a/src/main/scala/com/gu/automation/core/BaseFeatureSpec.scala
+++ b/src/main/scala/com/gu/automation/core/BaseFeatureSpec.scala
@@ -30,7 +30,7 @@ abstract class BaseFeatureSpec[T <: WebDriver] extends fixture.FeatureSpec with 
         MDC.put("testDate", DateTime.now.getMillis.toString)
         MDC.put("phase", "STEP")
         val tstashName = URLEncoder.encode(setName, "UTF-8")
-        val testRunId = Config().getTestRunId()
+        val testRunId = Config().getTestRunId().getOrElse("")
         val tstashURL = s"$tstashBaseURL/setLookup?setName=$tstashName&setDate=$setDate"
         logger.info(s"[StartInfo]$tstashURL $testRunId")
         logger.info("Test Name: " + td.name)

--- a/src/main/scala/com/gu/automation/core/BaseFeatureSpec.scala
+++ b/src/main/scala/com/gu/automation/core/BaseFeatureSpec.scala
@@ -30,8 +30,9 @@ abstract class BaseFeatureSpec[T <: WebDriver] extends fixture.FeatureSpec with 
         MDC.put("testDate", DateTime.now.getMillis.toString)
         MDC.put("phase", "STEP")
         val tstashName = URLEncoder.encode(setName, "UTF-8")
+        val testRunId = Config().getTestRunId()
         val tstashURL = s"$tstashBaseURL/setLookup?setName=$tstashName&setDate=$setDate"
-        logger.info(s"[URL]$tstashURL")
+        logger.info(s"[StartInfo]$tstashURL $testRunId")
         logger.info("Test Name: " + td.name)
 
         val driver = startDriver(td.name, browser)

--- a/src/main/scala/com/gu/automation/support/Config.scala
+++ b/src/main/scala/com/gu/automation/support/Config.scala
@@ -85,6 +85,10 @@ class Config(localFile: Option[Reader], projectFile: Option[Reader], frameworkFi
     getConfigValue("testBaseUrl")
   }
 
+  def getTestRunId(): Option[String] = {
+    getOption("testRunId")
+  }
+
   private def getOptionalUserContainer(user: Option[String]): com.typesafe.config.Config = {
     (user match {
       case None => config


### PR DESCRIPTION
Add optional testRunId to config, and pass to logger with TstashURL so that we can add to the file name of the test report in tstash-logger

@jamesoram @johnduffell 