### PR TITLE
Improve cookie manager and add API for HTML5 local storage

### DIFF
--- a/src/main/scala/com/gu/automation/support/CookieManager.scala
+++ b/src/main/scala/com/gu/automation/support/CookieManager.scala
@@ -26,4 +26,12 @@ object CookieManager {
     addCookies(List((cookieName,cookieValue)))
   }
 
+  def getCookie(cookieName: String)(implicit driver: WebDriver): Cookie = {
+    driver.manage().getCookieNamed(cookieName)
+  }
+
+  def removeCookie(cookieName: String)(implicit driver: WebDriver) = {
+    driver.manage().deleteCookieNamed(cookieName)
+  }
+
 }

--- a/src/main/scala/com/gu/automation/support/LocalStorageManager.scala
+++ b/src/main/scala/com/gu/automation/support/LocalStorageManager.scala
@@ -1,0 +1,21 @@
+package com.gu.automation.support
+
+import org.openqa.selenium.{JavascriptExecutor, WebDriver}
+
+import scala.util.Try
+
+object LocalStorageManager {
+
+  private def executeJavascript(javascript: String)(implicit driver: WebDriver): Try[String] = {
+    return Try(driver.asInstanceOf[JavascriptExecutor].executeScript(javascript).toString)
+  }
+
+  def remove(key: String)(implicit driver: WebDriver) = {
+    executeJavascript(s"localStorage.removeItem('$key');")
+  }
+
+  def set(key: String, value: String)(implicit driver: WebDriver) = {
+    executeJavascript(s"localStorage.setItem('$key', '$value');")
+  }
+
+}

--- a/src/main/scala/com/gu/automation/support/LocalStorageManager.scala
+++ b/src/main/scala/com/gu/automation/support/LocalStorageManager.scala
@@ -6,16 +6,20 @@ import scala.util.Try
 
 object LocalStorageManager {
 
+  private def stripQuotes(input: String): String = {
+    return input filterNot ("'\"" contains _)
+  }
+
   private def executeJavascript(javascript: String)(implicit driver: WebDriver): Try[String] = {
     return Try(driver.asInstanceOf[JavascriptExecutor].executeScript(javascript).toString)
   }
 
   def remove(key: String)(implicit driver: WebDriver) = {
-    executeJavascript(s"localStorage.removeItem('$key');")
+    executeJavascript("localStorage.removeItem(\"%s\");" format (stripQuotes(key)))
   }
 
   def set(key: String, value: String)(implicit driver: WebDriver) = {
-    executeJavascript(s"localStorage.setItem('$key', '$value');")
+    executeJavascript("localStorage.setItem(\"%s\", \"%s\");" format (stripQuotes(key), stripQuotes(value)))
   }
 
 }


### PR DESCRIPTION
For some new functional tests we need to be able to clear previous cookies and also interact with the HTML5 local storage API to clear a key.